### PR TITLE
🔀 :: (#7) - Create Module To Data Module

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.SSBAndroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/core/data/src/main/java/com/sweat/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/sweat/data/di/RepositoryModule.kt
@@ -6,6 +6,6 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-annotation class RepositoryModule {
+abstract class RepositoryModule {
     // todo : Add bindRepository Elements
 }

--- a/core/data/src/main/java/com/sweat/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/sweat/data/di/RepositoryModule.kt
@@ -1,0 +1,11 @@
+package com.sweat.data.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+annotation class RepositoryModule {
+    // todo : Add bindRepository Elements
+}


### PR DESCRIPTION
## 💡 개요
- :core:data의 경로에 위치한 data모듈에 필요한 RepositoryModule을 생성합니다.
## 📃 작업내용
- data모듈에 필요한 RepositoryModule과 di, repository와 같은 Package를 생성하였습니다.
## 🔀 변경사항
- add RepositoryModule(core:data:---:di:RepositoryModule)
- add repository Package
- add .gitkeep File
## 🙋‍♂️ 질문사항
- 이상한 부분이나 개선할 점이 있는 코드가 있다면 Comment 달아주세요.
## 🍴 사용방법
- Repository와 구현체를 생성한 후, 생성된 RepositoryModule에 각 인터페이스를 그 구현체와 연결하여, Hilt가 의존성 주입 시 구현체를 자동으로 주입하도록 해주는 **@Bind** 어노테이션을 사용하여 바인딩해주도록 합니다.
## 🎸 기타
- 🎸 