### PR TITLE
🔀 :: (#9) - Fix WorkManager Bug

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,3 +31,5 @@ include(":core:ui")
 
 include(":feature")
 include(":feature:splash")
+
+gradle.startParameter.excludedTaskNames.addAll(listOf(":build-logic:convention:testClasses"))


### PR DESCRIPTION
## 💡 개요
- 프로젝트에서 클린 -> 리빌드 과정에서 WorkManager가 문제가 있다는 에러가 나와서 이를 해결한다.
## 📃 작업내용
- root project단의 settings.gradle.kts 파일에 Gradle에게 작업 실행을 우회하도록 지시하여 오류를 방지하고 빌드를 진행할 수 있는 코드를 추가합니다.
- before
![스크린샷 2024-09-15 오전 12 51 25](https://github.com/user-attachments/assets/50f03142-312f-44b1-8406-3d2c1ccd18f7)

- after
![스크린샷 2024-09-15 오전 12 52 52](https://github.com/user-attachments/assets/9adb3f78-0723-447a-b104-2e1e18f91c83)

## 🔀 변경사항
- refactor settings.gradle.kts(root project)
## 🙋‍♂️ 질문사항
- 이상한 부분이 있다면 Comment를 달아주세요.
## 🍴 사용방법
- 불필요.
## 🎸 기타
- 🎸 