### PR TITLE
🔀 :: (#17) - DataSource 코드의 중복되는 코드를 개선하기 위한 함수를 만들었습니다.

### DIFF
--- a/core/common/src/main/java/com/sweat/common/exception/HttpException.kt
+++ b/core/common/src/main/java/com/sweat/common/exception/HttpException.kt
@@ -1,0 +1,57 @@
+package com.sweat.common.exception
+
+// 400: 올바르지 않은 요청
+class BadRequestException(
+    override val message: String?
+) : RuntimeException()
+
+// 401: 비인증 상태
+class UnauthorizedException(
+    override val message: String?
+) : RuntimeException()
+
+// 403: 권한이 없음
+class ForBiddenException(
+    override val message: String?
+) : RuntimeException()
+
+// 404: 요청한 리소스를 찾을 수 없음
+class NotFoundException(
+    override val message: String?
+) : RuntimeException()
+
+// 406: 클라이언트가 허용되지 않는 규격을 요청
+class NotAcceptableException(
+    override val message: String?
+) : RuntimeException()
+
+// 408: 요청시간초과
+class TimeOutException(
+    override val message: String?
+) : RuntimeException()
+
+// 409: 충돌발생
+class ConflictException(
+    override val message: String?
+) : RuntimeException()
+
+// 429: 너무 많은 요청
+class TooManyRequestException(
+    override val message: String?
+) : RuntimeException()
+
+// 50X: 서버에러
+class ServerException(
+    override val message: String?
+) : RuntimeException()
+
+// 정의되지 않은 HTTP 상태 코드나 사용자 정의 상태 코드
+class OtherHttpException(
+    val code: Int,
+    override val message: String?
+) : RuntimeException()
+
+// 예상하지 못한 에러
+class UnKnownException(
+    override val message: String?
+) : RuntimeException()

--- a/core/common/src/main/java/com/sweat/common/exception/InternetException.kt
+++ b/core/common/src/main/java/com/sweat/common/exception/InternetException.kt
@@ -1,0 +1,6 @@
+package com.sweat.common.exception
+
+class NoInternetException : RuntimeException() {
+    override val message: String
+        get() = "네트워크가 불안정합니다, 데이터나 와이파이 연결 상태를 확인부탁드립니다."
+}

--- a/core/common/src/main/java/com/sweat/common/exception/TokenExpirationException.kt
+++ b/core/common/src/main/java/com/sweat/common/exception/TokenExpirationException.kt
@@ -1,0 +1,8 @@
+package com.sweat.common.exception
+
+import java.io.IOException
+
+class TokenExpirationException : IOException() {
+    override val message: String
+        get() = "토큰이 만료되었습니다, 다시 로그인해주세요."
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     // todo : Add Other Project Implementation -> ex) implementation(project(":core:___")) / (project(":feature:____"))
+    implementation(project(":core:common"))
 
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.serialization.json)

--- a/core/network/src/main/java/com/sweat/network/util/SSBApiHandler.kt
+++ b/core/network/src/main/java/com/sweat/network/util/SSBApiHandler.kt
@@ -1,0 +1,54 @@
+package com.sweat.network.util
+
+import android.net.http.NetworkException
+import com.sweat.common.exception.*
+import retrofit2.HttpException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+class SSBApiHandler<T> {
+    private lateinit var httpRequest: suspend () -> T
+
+    fun httpRequest(httpRequest: suspend () -> T) =
+        this.apply { this.httpRequest = httpRequest }
+
+    suspend fun sendRequest(): T {
+        return try {
+            httpRequest.invoke()
+        } catch (e: HttpException) {
+            val message = e.message
+            throw when(e.code()) {
+                400 -> BadRequestException(
+                    message = message
+                )
+                401 -> UnauthorizedException(
+                    message = message
+                )
+                403 -> ForBiddenException(
+                    message = message
+                )
+                404 -> NotFoundException(
+                    message = message
+                )
+                409 -> ConflictException(
+                    message = message
+                )
+                500, 501, 502, 503 -> ServerException(
+                    message = message
+                )
+                else -> OtherHttpException(
+                    message = message,
+                    code = e.code()
+                )
+            }
+        } catch (e: SocketTimeoutException) {
+            throw TimeOutException(message = e.message)
+        } catch (e: UnknownHostException) {
+            throw NoInternetException()
+        } catch (e: TokenExpirationException) {
+            throw TokenExpirationException()
+        } catch (e: Exception) {
+            throw UnKnownException(message = e.message)
+        }
+    }
+}

--- a/core/network/src/main/java/com/sweat/network/util/performApiRequest.kt
+++ b/core/network/src/main/java/com/sweat/network/util/performApiRequest.kt
@@ -1,0 +1,14 @@
+package com.sweat.network.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+internal inline fun <reified T> performApiRequest(crossinline apiCall: suspend () -> T): Flow<T> = flow {
+    emit(
+        SSBApiHandler<T>()
+            .httpRequest{ apiCall() }
+            .sendRequest()
+    )
+}.flowOn(Dispatchers.IO)


### PR DESCRIPTION
## 💡 개요
- 개발 시작전 DataSource에서 중복되는 로직을 처리하기 위해 미리 함수화를 합니다.
## 📃 작업내용
- DataSource에서의 중복되는 로직을 처리하기 위해 Generic을 사용하여 비동기적인 동작 수행이 가능한 함수(performApiRequest)을 만들었습니다.
- 각각의 Exception을 추가하였습니다.
- 프로젝트의 ApiHandler를 추가하였습니다.
## 🔀 변경사항
- add HttpException
- add InternetException
- add TokenExpirationException
- refactor build.gradle.kts(:network) - Add Common Module Dependency
- add performApiRequest(Process Duplication Logic - DataSource)
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- DataSource 구현체를 작성을 할때 Api 요청 코드의 동일한 로직이 반복이 되는 부분이 있는데, 그러한 부분에 performApiRequest를 사용해주면 된다.
## 🎸 기타
- 🎸 