### PR TITLE
🔀 :: (#21) - Device에 대한 각각의 모델을 Preview에서도 확인이 가능하도록 했습니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
 dependencies {
     // todo : Add Other Project Implementation -> ex) implementation(project(":core:___")) / (project(":feature:____"))
+    implementation(project(":core:ui"))
 
     implementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)

--- a/app/src/main/java/com/sweat/ssb_android/MainActivity.kt
+++ b/app/src/main/java/com/sweat/ssb_android/MainActivity.kt
@@ -4,14 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.sweat.ssb_android.ui.theme.SSBAndroidTheme
+import com.sweat.ui.DevicePreviews
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -34,13 +38,19 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+    Box(
         modifier = modifier
-    )
+            .background(color = Color.White)
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Hello $name!",
+            modifier = modifier
+        )
+    }
 }
 
-@Preview(showBackground = true)
+@DevicePreviews
 @Composable
 fun GreetingPreview() {
     SSBAndroidTheme {

--- a/core/ui/src/main/java/com/sweat/ui/DevicePreviews.kt
+++ b/core/ui/src/main/java/com/sweat/ui/DevicePreviews.kt
@@ -1,0 +1,10 @@
+package com.sweat.ui
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(name = "phone_1", device = "spec:shape=Normal,width=360,height=880,unit=dp,dpi=480")
+@Preview(name = "phone_2", device = "spec:shape=Normal,width=412,height=732,unit=dp,dpi=420")
+@Preview(name = "s23", device = "spec:shape=Normal,width=360,height=780,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+annotation class DevicePreviews


### PR DESCRIPTION
## 💡 개요
- Device에 대한 각각의 모델을 Preview에서도 확인이 가능하도록 할 수 있는 Preview에서 사용을 하는 어노테이션이 필요해보였습니다.
## 📃 작업내용
- DevicePreviews라는 어노테이션을 추가하였습니다. 

- before
<img width="125" alt="스크린샷 2024-09-26 오후 8 29 07" src="https://github.com/user-attachments/assets/0d4d6a02-31b2-4f86-bf8b-c401a62c6fe4">

- after
<img width="513" alt="스크린샷 2024-09-26 오후 8 28 50" src="https://github.com/user-attachments/assets/8e20c3e1-f791-40cb-9248-edfd5a10add3">

## 🔀 변경사항
- add DevicePreviews
- chore build.gradle.kts(:app)
- chore MainActivity
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- Screen에서 Preview 어노테이션 대신 @DevicePreviews를 사용하면 됩니다.
## 🎸 기타
- x